### PR TITLE
implementation of keys, scroll, drag, etc. 

### DIFF
--- a/ui_act/Cargo.lock
+++ b/ui_act/Cargo.lock
@@ -1460,9 +1460,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/ui_act/src/env.rs
+++ b/ui_act/src/env.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use std::time::Duration;
 
 pub mod full_desktop;
 pub mod single_window;
@@ -7,15 +8,29 @@ pub trait ComputerEnvironment {
     fn name(&self) -> String;
     fn width(&self) -> Result<u32>;
     fn height(&self) -> Result<u32>;
+    
+    // General actions
     fn screenshot(&self) -> Result<image::RgbImage>;
+    fn wait(&mut self, duration: Duration) -> Result<()>;
+    fn scroll(&mut self, direction: &str, amount: u32) -> Result<()>;
 
     // Mouse actions
     fn mouse_move(&mut self, x: u32, y: u32) -> Result<()>;
-    fn left_click(&mut self) -> Result<()>;
-    fn right_click(&mut self) -> Result<()>;
-    fn double_click(&mut self) -> Result<()>;
+    fn cursor_position(&mut self) -> Result<(u32, u32)>;
 
+    fn left_mouse_down(&mut self) -> Result<()>;
+    fn left_mouse_up(&mut self) -> Result<()>;
+    fn left_click(&mut self) -> Result<()>;
+    fn left_click_drag(&mut self, x: u32, y: u32) -> Result<()>;
+    
+    fn right_click(&mut self) -> Result<()>;
+    fn middle_click(&mut self) -> Result<()>;
+    fn double_click(&mut self) -> Result<()>;
+    fn triple_click(&mut self) -> Result<()>;
+    
     // Keyboard actions
+    fn hold_key(&mut self, key: &str, duration: Duration) -> Result<()>;
     fn type_text(&mut self, text: &str) -> Result<()>;
     fn press_key(&mut self, key_combination: &str) -> Result<()>;
+
 }

--- a/ui_act/src/env/full_desktop.rs
+++ b/ui_act/src/env/full_desktop.rs
@@ -4,6 +4,9 @@ use xcap::Monitor;
 use crate::env::ComputerEnvironment;
 use crate::utils::get_first_monitor;
 use crate::input::MPXInput;
+use crate::device::{MouseButton, ScrollDirection};
+use std::thread;
+use std::time::Duration;
 
 pub struct FullDesktopEnvironment {
     input: MPXInput,
@@ -39,20 +42,62 @@ impl ComputerEnvironment for FullDesktopEnvironment {
         Ok(rgb_image)
     }
 
+    fn wait(&mut self, duration: Duration) -> Result<()> {
+        thread::sleep(duration);
+        Ok(())
+    }
+
+    fn scroll(&mut self, direction: &str, amount: u32) -> Result<()> {
+        self.input.mouse.scroll(ScrollDirection::from_str(direction)?, amount)
+    }
+
+    // Mouse Actions
+
     fn mouse_move(&mut self, x: u32, y: u32) -> Result<()> {
         self.input.mouse.mouse_move(x, y)
     }
 
+    fn cursor_position(&mut self) -> Result<(u32, u32)> {
+        // self.input.mouse.cursor_position()
+        Ok((0, 0))
+    }
+
+    fn left_mouse_down(&mut self) -> Result<()> {
+        self.input.mouse.mouse_down(MouseButton::Left)
+    }
+
+    fn left_mouse_up(&mut self) -> Result<()> {
+        self.input.mouse.mouse_up(MouseButton::Left)
+    }
+
+    fn left_click_drag(&mut self, x: u32, y: u32) -> Result<()> {
+        self.input.mouse.click_drag(MouseButton::Left, x, y)
+    }
+
     fn left_click(&mut self) -> Result<()> {
-        self.input.mouse.left_click()
+        self.input.mouse.click(MouseButton::Left)
     }
 
     fn right_click(&mut self) -> Result<()> {
-        self.input.mouse.right_click()
+        self.input.mouse.click(MouseButton::Right)
+    }
+
+    fn middle_click(&mut self) -> Result<()> {
+        self.input.mouse.click(MouseButton::Middle)
     }
 
     fn double_click(&mut self) -> Result<()> {
         self.input.mouse.double_click()
+    }
+
+    fn triple_click(&mut self) -> Result<()> {
+        self.input.mouse.triple_click()
+    }
+
+    // Keyboard Actions
+
+    fn hold_key(&mut self, key: &str, duration: Duration) -> Result<()> {
+        self.input.keyboard.hold_key(key, duration)
     }
 
     fn type_text(&mut self, text: &str) -> Result<()> {
@@ -62,4 +107,5 @@ impl ComputerEnvironment for FullDesktopEnvironment {
     fn press_key(&mut self, key_combination: &str) -> Result<()> {
         self.input.keyboard.press_key(key_combination)
     }
+
 }

--- a/ui_act/src/env/single_window.rs
+++ b/ui_act/src/env/single_window.rs
@@ -7,6 +7,8 @@ use x11rb::connection::Connection;
 use crate::input::MPXInput;
 use crate::env::ComputerEnvironment;
 use crate::utils::get_first_monitor;
+use crate::device::{MouseButton, ScrollDirection};
+use std::time::Duration;
 
 pub struct SingleWindowEnvironment {
     input: MPXInput,
@@ -131,16 +133,53 @@ impl ComputerEnvironment for SingleWindowEnvironment {
         self.input.mouse.mouse_move(geom.x as u32 + x, geom.y as u32 + y)
     }
 
+    fn cursor_position(&mut self) -> Result<(u32, u32)> {
+        Ok((0, 0)) // todo: implement
+    }
+
+    fn left_mouse_down(&mut self) -> Result<()> {
+        self.input.mouse.mouse_down(MouseButton::Left)
+    }
+
+    fn left_mouse_up(&mut self) -> Result<()> {
+        self.input.mouse.mouse_up(MouseButton::Left)
+    }
+
+    fn left_click_drag(&mut self, x: u32, y: u32) -> Result<()> {
+        self.input.mouse.click_drag(MouseButton::Left, x, y)
+    }
+
     fn left_click(&mut self) -> Result<()> {
-        self.input.mouse.left_click()
+        self.input.mouse.click(MouseButton::Left)
     }
 
     fn right_click(&mut self) -> Result<()> {
-        self.input.mouse.right_click()
+        self.input.mouse.click(MouseButton::Right)
+    }
+
+    fn middle_click(&mut self) -> Result<()> {
+        self.input.mouse.click(MouseButton::Middle)
     }
 
     fn double_click(&mut self) -> Result<()> {
         self.input.mouse.double_click()
+    }
+
+    fn triple_click(&mut self) -> Result<()> {
+        self.input.mouse.triple_click()
+    }
+
+    fn wait(&mut self, duration: Duration) -> Result<()> {
+        std::thread::sleep(duration);
+        Ok(())
+    }
+
+    fn scroll(&mut self, direction: &str, amount: u32) -> Result<()> {
+        self.input.mouse.scroll(ScrollDirection::from_str(direction)?, amount)
+    }
+
+    fn hold_key(&mut self, key: &str, duration: Duration) -> Result<()> {
+        self.input.keyboard.hold_key(key, duration)
     }
 
     fn type_text(&mut self, text: &str) -> Result<()> {
@@ -150,6 +189,7 @@ impl ComputerEnvironment for SingleWindowEnvironment {
     fn press_key(&mut self, key_combination: &str) -> Result<()> {
         self.input.keyboard.press_key(key_combination)
     }
+
 }
 
 impl Drop for SingleWindowEnvironment {


### PR DESCRIPTION
 - **Keys**
   - Adds more keys, though admittedly it assumes american keyboard layout which is a problem. 
   - Changes to match to push blocks to support some special characters that aren't seen as uppercase, but need a leftShift (not happy with it, but worked)
   - Adds hold_key support 
 - **Mouse**
   - adds left_click_drag, mouse_down, mouse_up, scroll 
     - _Note: there is a potential future compat issue with the high-res mouse wheel event uinput.h offers, but the rust wrapper does not_ 
   - moves clicks to some more general private functions that can be composed into higher order actions like double click, drag, etc.
 - **General**
   - Adds a combined signal handler so we don't need to copy the telemetry call each time we add a new signal we should stop on
   - Adds graceful cleanup of the multipointer masters created (caused issues with inputs when exiting during testing when the devices remained)


